### PR TITLE
Add some string cases. Also tests.

### DIFF
--- a/lib/lazy_float.ex
+++ b/lib/lazy_float.ex
@@ -22,7 +22,7 @@ defmodule Ecto.LazyFloat do
   def blank?(_), do: false
   
   def load(float) when is_float(float), do: {:ok, float}
-  def load(integer) when is_integer(integer), do {:ok, integer / 1}
+  def load(integer) when is_integer(integer), do: {:ok, integer / 1}
   def load(_), do: :error
   
   def dump(float) when is_float(float), do: {:ok, float}

--- a/lib/lazy_float.ex
+++ b/lib/lazy_float.ex
@@ -2,6 +2,7 @@ defmodule Ecto.LazyFloat do
 
   def type, do: :float
 
+  def cast(string) when is_binary(string) and sitrng == "", do: {:ok, nil}
   def cast(string) when is_binary(string) do
     case Float.parse(string) do
       {float, _} -> {:ok, float}

--- a/lib/lazy_float.ex
+++ b/lib/lazy_float.ex
@@ -10,20 +10,20 @@ defmodule Ecto.LazyFloat do
       :error   -> :error
     end
   end
-
   def cast(integer) when is_integer(integer) do
     case Float.parse(to_string(integer)) do
       {float, _} -> {:ok, float}
       :error   -> :error
     end
   end
-
   def cast(float) when is_float(float), do: {:ok, float}
-
   def cast(_), do: :error
+
   def blank?(_), do: false
   
   def load(float) when is_float(float), do: {:ok, float}
+  def load(integer) when is_integer(integer), do {:ok, integer / 1}
+  def load(_), do: :error
   
   def dump(float) when is_float(float), do: {:ok, float}
   def dump(_), do: :error

--- a/lib/lazy_float.ex
+++ b/lib/lazy_float.ex
@@ -4,6 +4,7 @@ defmodule Ecto.LazyFloat do
 
   def cast(string) when is_binary(string) and string == "", do: {:ok, nil}
   def cast(string) when is_binary(string) do
+    if Regex.match?(~r/^\.[0-9]+$/, string), do: string = "0" <> string
     case Float.parse(string) do
       {float, _} -> {:ok, float}
       :error   -> :error

--- a/lib/lazy_float.ex
+++ b/lib/lazy_float.ex
@@ -3,8 +3,10 @@ defmodule Ecto.LazyFloat do
   def type, do: :float
 
   def cast(""), do: {:ok, nil}
+  def cast("." <> string) do
+    cast("0." <> string)
+  end
   def cast(string) when is_binary(string) do
-    if Regex.match?(~r/^\.[0-9]+$/, string), do: string = "0" <> string
     case Float.parse(string) do
       {float, _} -> {:ok, float}
       :error   -> :error

--- a/lib/lazy_float.ex
+++ b/lib/lazy_float.ex
@@ -2,7 +2,7 @@ defmodule Ecto.LazyFloat do
 
   def type, do: :float
 
-  def cast(string) when is_binary(string) and string == "", do: {:ok, nil}
+  def cast(""), do: {:ok, nil}
   def cast(string) when is_binary(string) do
     if Regex.match?(~r/^\.[0-9]+$/, string), do: string = "0" <> string
     case Float.parse(string) do

--- a/lib/lazy_float.ex
+++ b/lib/lazy_float.ex
@@ -2,7 +2,7 @@ defmodule Ecto.LazyFloat do
 
   def type, do: :float
 
-  def cast(string) when is_binary(string) and sitrng == "", do: {:ok, nil}
+  def cast(string) when is_binary(string) and string == "", do: {:ok, nil}
   def cast(string) when is_binary(string) do
     case Float.parse(string) do
       {float, _} -> {:ok, float}

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule LazyFloat.Mixfile do
 
   def project do
     [app: :ecto_lazy_float,
-     version: "0.1.2",
+     version: "0.1.3",
      elixir: "~> 1.0",
      name: "Ecto.LazyFloat",
      description: description(),

--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,9 @@ defmodule LazyFloat.Mixfile do
      version: "0.1.2",
      elixir: "~> 1.0",
      name: "Ecto.LazyFloat",
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   def application do

--- a/test/lazy_float_test.exs
+++ b/test/lazy_float_test.exs
@@ -1,0 +1,42 @@
+defmodule LazyFloatTest do
+  use ExUnit.Case
+  alias Ecto.Repo
+  import Ecto.Changeset
+  
+  defmodule TestModule do
+    use Ecto.Model
+
+    schema "test_module" do
+      field :test_field, Ecto.LazyFloat
+    end
+  end
+
+  describe "An attribute with LazyFloat" do
+    test "casts an integer to a float correctly" do
+      assert changeset_valid?(%{test_field: 1})
+    end
+
+    test "casts a string to an float correctly" do
+      assert changeset_valid?(%{test_field: "0.1"})
+      assert changeset_valid?(%{test_field: ".1"})
+    end
+
+    test "can receive an float correctly" do
+      assert changeset_valid?(%{test_field: 1})
+    end
+
+    test "throws an error otherwise" do
+      refute changeset_valid?(%{test_field: "wrong_value"})
+      refute changeset_valid?(%{test_field: false})
+      refute changeset_valid?(%{test_field: []})
+      refute changeset_valid?(%{test_field: %{}})
+    end
+  end
+
+  defp changeset_valid?(changes) do
+    changeset = %TestModule{}
+      |> cast(changes, ["test_field"], [])
+      |> validate_change(:test_field, fn(_, v) -> if is_float(v), do: [] end)
+      |> Map.get(:valid?)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Hi!

Since the time I wrote the issue another case came up besides the empty string to nil one. As it is right now `Ecto.LazyFloat` cannot parse strings like this:
```elixir
iex(5)> Float.parse(".3")
:error
```
The fix I propose is appending the "0" to the beginning of a string that matches the regular expression `~r/^\.[0-9]+$/`.

Also I added a couple of tests to the project, just for completeness. WDYT?